### PR TITLE
Updating test as Loopback framework DELETE method now returns 200 ins…

### DIFF
--- a/test/authenticated.js
+++ b/test/authenticated.js
@@ -48,7 +48,7 @@ describe('Authenticated User', function() {
 
   it('successfully deletes a blog where current user is the owner', function(done) {
     api.delete('/blogs/test-blog-delete-me?access_token='+accessToken)
-    .expect(204, done);
+    .expect(200, done);
   });
 
   it('returns a 401 when deleting a blog where current user is NOT the owner', function(done) {


### PR DESCRIPTION
…tead of 204
When calling DELETE on a resource, the response code used to be 204, lately it returns 200 with an empty body. See: https://github.com/strongloop/loopback/issues/1322
